### PR TITLE
Allow bsg_fakeram to be installed in a shared directory

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -2,6 +2,7 @@
 
 import sys
 import json
+import argparse
 
 from utils.class_process import Process
 from utils.class_memory import Memory
@@ -20,15 +21,35 @@ from utils.generate_verilog import generate_verilog_bb
 # found in the JSON configuration file.
 ################################################################################
 
-def main ( argc, argv ):
+def get_args() -> argparse.Namespace:
+    """
+    Get command line arguments
+    """
+    parser = argparse.ArgumentParser(
+        description="""
+    BSG Black-box SRAM Generator --
+    This project is designed to generate black-boxed SRAMs for use in CAD
+    flows where either an SRAM generator is not avaible or doesn't
+    exist.  """
+    )
 
-  # Check the command line arguments
-  if argc != 2:
-    print('Usage: %s <json cfg>' % argv[0])
-    sys.exit(1)
+    parser.add_argument("config", help="JSON configuration file")
+
+    parser.add_argument(
+        "--output_dir", action="store", help="Output directory ", required=False, default=None
+    )
+
+    parser.add_argument(
+        "--cacti_dir", action="store", help="CACTI installation directory ", required=False, default=None
+    )
+
+    return parser.parse_args()
+
+
+def main ( args : argparse.Namespace):
 
   # Load the JSON configuration file
-  with open(argv[1], 'r') as fid:
+  with open(args.config, 'r') as fid:
     raw = [line.strip() for line in fid if not line.strip().startswith('#')]
   json_data = json.loads('\n'.join(raw))
 
@@ -37,7 +58,7 @@ def main ( argc, argv ):
 
   # Go through each sram and generate the lib, lef and v files
   for sram_data in json_data['srams']:
-    memory = Memory(process, sram_data)
+    memory = Memory(process, sram_data, args.output_dir, args.cacti_dir)
     generate_lib(memory)
     generate_lef(memory)
     generate_verilog(memory)
@@ -45,5 +66,6 @@ def main ( argc, argv ):
 
 ### Entry point
 if __name__ == '__main__':
-  main( len(sys.argv), sys.argv )
+  args = get_args()
+  main( args )
 

--- a/scripts/utils/class_memory.py
+++ b/scripts/utils/class_memory.py
@@ -1,6 +1,6 @@
 import math
 import os
-
+from pathlib import Path
 from utils.cacti_config import cacti_config
 
 ################################################################################
@@ -25,7 +25,8 @@ class Memory:
     self.width_in_bytes = math.ceil(self.width_in_bits / 8.0)
     self.total_size     = self.width_in_bytes * self.depth
     if output_dir: # Output dir was set by command line option
-      self.results_dir = os.sep.join([output_dir, self.name])
+      p = str(Path(output_dir).expanduser().resolve(strict=False))
+      self.results_dir = os.sep.join([p, self.name])
     else:
       self.results_dir = os.sep.join([os.getcwd(), 'results', self.name])
     if not os.path.exists( self.results_dir ):
@@ -69,6 +70,7 @@ class Memory:
     fid.close()
     odir = os.getcwd()
     os.chdir(self.cacti_dir )
-    os.system( os.sep.join(['.','cacti -infile ']) + os.sep.join([self.results_dir,'cacti.cfg']))
+    cmd = os.sep.join(['.','cacti -infile ']) + os.sep.join([self.results_dir,'cacti.cfg'])
+    os.system( cmd)
     os.chdir(odir)
 

--- a/scripts/utils/class_memory.py
+++ b/scripts/utils/class_memory.py
@@ -14,7 +14,7 @@ from utils.cacti_config import cacti_config
 
 class Memory:
 
-  def __init__( self, process, sram_data ):
+  def __init__( self, process, sram_data , output_dir = None, cacti_dir = None):
 
     self.process        = process
     self.name           = str(sram_data['name'])
@@ -24,11 +24,16 @@ class Memory:
     self.rw_ports       = 1
     self.width_in_bytes = math.ceil(self.width_in_bits / 8.0)
     self.total_size     = self.width_in_bytes * self.depth
-
-    self.results_dir = os.sep.join([os.getcwd(), 'results', self.name])
+    if output_dir: # Output dir was set by command line option
+      self.results_dir = os.sep.join([output_dir, self.name])
+    else:
+      self.results_dir = os.sep.join([os.getcwd(), 'results', self.name])
     if not os.path.exists( self.results_dir ):
       os.makedirs( self.results_dir )
-
+    if cacti_dir:
+      self.cacti_dir = cacti_dir
+    else:
+      self.cacti_dir = os.environ['CACTI_BUILD_DIR']
     self.__run_cacti()
     with open( os.sep.join([self.results_dir, 'cacti.cfg.out']), 'r' ) as fid:
       lines = [line for line in fid]
@@ -63,7 +68,7 @@ class Memory:
              , self.process.tech_um, self.width_in_bits, self.num_banks ))
     fid.close()
     odir = os.getcwd()
-    os.chdir(os.environ['CACTI_BUILD_DIR'] )
+    os.chdir(self.cacti_dir )
     os.system( os.sep.join(['.','cacti -infile ']) + os.sep.join([self.results_dir,'cacti.cfg']))
     os.chdir(odir)
 


### PR DESCRIPTION
Add option --output_dir to override default './result' directory
Add option --cacti_dir to specific CACTI installation directory

Default behaviour should be unchanged

Tool can be called like this now:
`/scripts/run.py --output_dir=~/tmp/fakeram --cacti_dir=./tools/cacti ./example_cfgs/freepdk45.cfg`