### PR TITLE
Add Verilog time check signal expansion option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,16 @@ export CACTI_BUILD_DIR := $(TOP_DIR)/tools/cacti
 
 CONFIG := $(TOP_DIR)/example_cfgs/freepdk45.cfg
 
+OUT_DIR := $(TOP_DIR)/results
+
 run:
-	./scripts/run.py $(CONFIG)
+	./scripts/run.py $(CONFIG) --output_dir $(OUT_DIR)
 
 view.%:
-	klayout ./results/$*/$*.lef &
+	klayout ./$(OUT_DIR)/$*/$*.lef &
 
 clean:
-	rm -rf ./results
+	rm -rf ./$(OUT_DIR)
 
 #=======================================
 # TOOLS

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -61,7 +61,7 @@ def main ( args : argparse.Namespace):
     memory = Memory(process, sram_data, args.output_dir, args.cacti_dir)
     generate_lib(memory)
     generate_lef(memory)
-    generate_verilog(memory)
+    generate_verilog(memory, tmChkExpand=process.vlogTimingCheckSignalExpansion)
     generate_verilog_bb(memory)
 
 ### Entry point

--- a/scripts/utils/class_process.py
+++ b/scripts/utils/class_process.py
@@ -23,6 +23,7 @@ class Process:
     self.snapHeight_nm  = int(json_data['snapHeight_nm']) if 'snapHeight_nm' in json_data else 1
     self.flipPins       = str(json_data['flipPins']) if 'flipPins' in json_data else 'false'
     self.pinHeight_nm   = int(json_data['pinHeight_nm']) if 'pinHeight_nm' in json_data else (self.pinWidth_nm) # Default to square pins
+    self.vlogTimingCheckSignalExpansion = bool(json_data['vlogTimingCheckSignalExpansion']) if 'vlogTimingCheckSignalExpansion' in json_data else False
 
     # Converted values
     self.tech_um     = self.tech_nm / 1000.0

--- a/scripts/utils/generate_verilog.py
+++ b/scripts/utils/generate_verilog.py
@@ -7,155 +7,144 @@ import math
 # Generate a .v file based on the given SRAM.
 ################################################################################
 
-def generate_verilog( mem ):
+def generate_verilog(mem, tmChkExpand=False):
+  '''Generate a verilog view for the RAM'''
+  name  = str(mem.name)
+  depth = int(mem.depth)
+  bits  = int(mem.width_in_bits)
+  addr_width = math.ceil(math.log2(depth))
+  crpt_on_x = 1
 
-    name  = str(mem.name)
-    depth = int(mem.depth)
-    bits  = int(mem.width_in_bits)
-    num_rwport = mem.rw_ports
-    addr_width = math.ceil(math.log2(depth))
+  # Generate the 'setuphold' timing checks
+  setuphold_checks  = SH_LINE.format(sig='       we_in')
+  setuphold_checks += SH_LINE.format(sig='       ce_in')
+  if tmChkExpand: # per-bit checks
+    for i in range(addr_width): setuphold_checks += SH_LINE.format(sig=f'  addr_in[{i}]')
+    for i in range(      bits): setuphold_checks += SH_LINE.format(sig=f'    wd_in[{i}]')
+    for i in range(      bits): setuphold_checks += SH_LINE.format(sig=f'w_mask_in[{i}]')
+  else: # per-signal checks
+    setuphold_checks += SH_LINE.format(sig='     addr_in')
+    setuphold_checks += SH_LINE.format(sig='       wd_in')
+    setuphold_checks += SH_LINE.format(sig='   w_mask_in')
 
-    V_file = open(os.sep.join([mem.results_dir, name + '.v']), 'w')
-
-    V_file.write('module %s\n' % name)
-    V_file.write('(\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   rd_out,\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   addr_in,\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   we_in,\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   wd_in,\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   w_mask_in,\n')
-    V_file.write('   clk,\n')
-    V_file.write('   ce_in\n')
-    V_file.write(');\n')
-    V_file.write('   parameter BITS = %s;\n' % str(bits))
-    V_file.write('   parameter WORD_DEPTH = %s;\n' % str(depth))
-    V_file.write('   parameter ADDR_WIDTH = %s;\n' % str(addr_width))
-    V_file.write('   parameter corrupt_mem_on_X_p = 1;\n')
-    V_file.write('\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   output reg [BITS-1:0]    rd_out;\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   input  [ADDR_WIDTH-1:0]  addr_in;\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   input                    we_in;\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   input  [BITS-1:0]        wd_in;\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   input  [BITS-1:0]        w_mask_in;\n')
-    V_file.write('   input                    clk;\n')
-    V_file.write('   input                    ce_in;\n')
-    V_file.write('\n')
-    V_file.write('   reg    [BITS-1:0]        mem [0:WORD_DEPTH-1];\n')
-    V_file.write('\n')
-    V_file.write('   integer j;\n')
-    V_file.write('\n')
-    V_file.write('   always @(posedge clk)\n')
-    V_file.write('   begin\n')
-    V_file.write('      if (ce_in)\n')
-    V_file.write('      begin\n')
-    for i in range(int(num_rwport)) :
-      V_file.write("         //if ((we_in !== 1'b1 && we_in !== 1'b0) && corrupt_mem_on_X_p)\n")
-      V_file.write('         if (corrupt_mem_on_X_p &&\n')
-      V_file.write("             ((^we_in === 1'bx) || (^addr_in === 1'bx))\n")
-      V_file.write('            )\n')
-      V_file.write('         begin\n')
-      V_file.write('            // WEN or ADDR is unknown, so corrupt entire array (using unsynthesizeable for loop)\n')
-      V_file.write('            for (j = 0; j < WORD_DEPTH; j = j + 1)\n')
-      V_file.write("               mem[j] <= 'x;\n")
-      V_file.write('            $display("warning: ce_in=1, we_in is %b, addr_in = %x in ' + name + '", we_in, addr_in);\n')
-      V_file.write('         end\n')
-      V_file.write('         else if (we_in)\n')
-      V_file.write('         begin\n')
-      V_file.write('            mem[addr_in] <= (wd_in & w_mask_in) | (mem[addr_in] & ~w_mask_in);\n')
-      V_file.write('         end\n')
-    V_file.write('         // read\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('         rd_out <= mem[addr_in];\n')
-    V_file.write('      end\n')
-    V_file.write('      else\n')
-    V_file.write('      begin\n')
-    V_file.write("         // Make sure read fails if ce_in is low\n")
-    V_file.write("         rd_out <= 'x;\n")
-    V_file.write('      end\n')
-    V_file.write('   end\n')
-    V_file.write('\n')
-    V_file.write('   // Timing check placeholders (will be replaced during SDF back-annotation)\n')
-    V_file.write('   reg notifier;\n')
-    V_file.write('   specify\n')
-    V_file.write('      // Delay from clk to rd_out\n')
-    V_file.write('      (posedge clk *> rd_out) = (0, 0);\n')
-    V_file.write('\n')
-    V_file.write('      // Timing checks\n')
-    V_file.write('      $width     (posedge clk,            0, 0, notifier);\n')
-    V_file.write('      $width     (negedge clk,            0, 0, notifier);\n')
-    V_file.write('      $period    (posedge clk,            0,    notifier);\n')
-    V_file.write('      $setuphold (posedge clk, we_in,     0, 0, notifier);\n')
-    V_file.write('      $setuphold (posedge clk, ce_in,     0, 0, notifier);\n')
-    V_file.write('      $setuphold (posedge clk, addr_in,   0, 0, notifier);\n')
-    V_file.write('      $setuphold (posedge clk, wd_in,     0, 0, notifier);\n')
-    V_file.write('      $setuphold (posedge clk, w_mask_in, 0, 0, notifier);\n')
-    V_file.write('   endspecify\n')
-    V_file.write('\n')
-    V_file.write('endmodule\n')
-
-    V_file.close()
-
-################################################################################
-# GENERATE VERILOG BLACKBOX VIEW
-#
-# Generate a .bb.v file based on the given SRAM. This is the same as the
-# standard verilog view but only has the module definition and port
-# declarations (no internal logic).
-################################################################################
+  fout = os.sep.join([mem.results_dir, name + '.v'])
+  with open(fout, 'w') as f:
+    f.write(VLOG_TEMPLATE.format(name=name, data_width=bits, depth=depth, addr_width=addr_width, 
+      crpt_on_x=crpt_on_x, setuphold_checks=setuphold_checks))
 
 def generate_verilog_bb( mem ):
+  '''Generate a verilog black-box view for the RAM'''
+  name  = str(mem.name)
+  depth = int(mem.depth)
+  bits  = int(mem.width_in_bits)
+  addr_width = math.ceil(math.log2(depth))
+  crpt_on_x = 1
 
-    name  = str(mem.name)
-    depth = int(mem.depth)
-    bits  = int(mem.width_in_bits)
-    num_rwport = mem.rw_ports
-    addr_width = math.ceil(math.log2(depth))
+  fout = os.sep.join([mem.results_dir, name + '.bb.v'])
+  with open(fout, 'w') as f:
+    f.write(VLOG_BB_TEMPLATE.format(name=name, data_width=bits, depth=depth, addr_width=addr_width, 
+      crpt_on_x=crpt_on_x))
 
-    V_file = open(os.sep.join([mem.results_dir, name + '.bb.v']), 'w')
+# Template line for a 'setuphold' time check
+SH_LINE = '      $setuphold (posedge clk, {sig}, 0, 0, notifier);\n'
 
-    V_file.write('module %s\n' % name)
-    V_file.write('(\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   rd_out,\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   addr_in,\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   we_in,\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   wd_in,\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   w_mask_in,\n')
-    V_file.write('   clk,\n')
-    V_file.write('   ce_in\n')
-    V_file.write(');\n')
-    V_file.write('   parameter BITS = %s;\n' % str(bits))
-    V_file.write('   parameter WORD_DEPTH = %s;\n' % str(depth))
-    V_file.write('   parameter ADDR_WIDTH = %s;\n' % str(addr_width))
-    V_file.write('   parameter corrupt_mem_on_X_p = 1;\n')
-    V_file.write('\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   output reg [BITS-1:0]    rd_out;\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   input  [ADDR_WIDTH-1:0]  addr_in;\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   input                    we_in;\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   input  [BITS-1:0]        wd_in;\n')
-    for i in range(int(num_rwport)) :
-      V_file.write('   input  [BITS-1:0]        w_mask_in;\n')
-    V_file.write('   input                    clk;\n')
-    V_file.write('   input                    ce_in;\n')
-    V_file.write('\n')
-    V_file.write('endmodule\n')
-    V_file.close()
+# Template for a verilog 1rw RAM model
+VLOG_TEMPLATE = '''\
+module {name}
+(
+   rd_out,
+   addr_in,
+   we_in,
+   wd_in,
+   w_mask_in,
+   clk,
+   ce_in
+);
+   parameter BITS = {data_width};
+   parameter WORD_DEPTH = {depth};
+   parameter ADDR_WIDTH = {addr_width};
+   parameter corrupt_mem_on_X_p = {crpt_on_x};
 
+   output reg [BITS-1:0]    rd_out;
+   input  [ADDR_WIDTH-1:0]  addr_in;
+   input                    we_in;
+   input  [BITS-1:0]        wd_in;
+   input  [BITS-1:0]        w_mask_in;
+   input                    clk;
+   input                    ce_in;
+
+   reg    [BITS-1:0]        mem [0:WORD_DEPTH-1];
+
+   integer j;
+
+   always @(posedge clk)
+   begin
+      if (ce_in)
+      begin
+         //if ((we_in !== 1'b1 && we_in !== 1'b0) && corrupt_mem_on_X_p)
+         if (corrupt_mem_on_X_p &&
+             ((^we_in === 1'bx) || (^addr_in === 1'bx))
+            )
+         begin
+            // WEN or ADDR is unknown, so corrupt entire array (using unsynthesizeable for loop)
+            for (j = 0; j < WORD_DEPTH; j = j + 1)
+               mem[j] <= 'x;
+            $display("warning: ce_in=1, we_in is %b, addr_in = %x in fakeram_d64_w8", we_in, addr_in);
+         end
+         else if (we_in)
+         begin
+            mem[addr_in] <= (wd_in & w_mask_in) | (mem[addr_in] & ~w_mask_in);
+         end
+         // read
+         rd_out <= mem[addr_in];
+      end
+      else
+      begin
+         // Make sure read fails if ce_in is low
+         rd_out <= 'x;
+      end
+   end
+
+   // Timing check placeholders (will be replaced during SDF back-annotation)
+   reg notifier;
+   specify
+      // Delay from clk to rd_out
+      (posedge clk *> rd_out) = (0, 0);
+
+      // Timing checks
+      $width     (posedge clk,               0, 0, notifier);
+      $width     (negedge clk,               0, 0, notifier);
+      $period    (posedge clk,               0,    notifier);
+{setuphold_checks}
+   endspecify
+
+endmodule
+'''
+
+# Template for a verilog 1rw RAM interface
+VLOG_BB_TEMPLATE = '''\
+module {name}
+(
+   rd_out,
+   addr_in,
+   we_in,
+   wd_in,
+   w_mask_in,
+   clk,
+   ce_in
+);
+   parameter BITS = {data_width};
+   parameter WORD_DEPTH = {depth};
+   parameter ADDR_WIDTH = {addr_width};
+   parameter corrupt_mem_on_X_p = {crpt_on_x};
+
+   output reg [BITS-1:0]    rd_out;
+   input  [ADDR_WIDTH-1:0]  addr_in;
+   input                    we_in;
+   input  [BITS-1:0]        wd_in;
+   input  [BITS-1:0]        w_mask_in;
+   input                    clk;
+   input                    ce_in;
+
+endmodule
+'''


### PR DESCRIPTION
* Create a new optional config variable. When set 'true', the $setuphold lines in the verilog model are written differently. Instead of one line per signal, one line is written for every bit of every signal. This is for tool compatibility. 
* Generally update the verilog model writing by using a template string
* Expose the `--output_dir` argument of the main script to the Makefile